### PR TITLE
Prevent (async () => {})() from causing ASTring to throw an error.

### DIFF
--- a/lib/global/rewrite/js/process.ts
+++ b/lib/global/rewrite/js/process.ts
@@ -1,14 +1,14 @@
 import DynamicRewrites from "../../rewrite";
 import js from "./js";
 
-export default function process (this: js, src: string, config: Object | any = {}, ctx: any, dynamic: Object | any) {
-    var ast = this.ctx.modules.acorn.parse(src.toString(), {sourceType: config.module ? 'module' : 'script', allowImportExportEverywhere: true, allowAwaitOutsideFunction: true, allowReturnOutsideFunction: true, ecmaVersion: "latest", preserveParens: true, loose: true, allowReserved: true});
+export default function process(this: js, src: string, config: Object | any = {}, ctx: any, dynamic: Object | any) {
+  var ast = this.ctx.modules.acorn.parse(src.toString(), { sourceType: config.module ? 'module' : 'script', allowImportExportEverywhere: true, allowAwaitOutsideFunction: true, allowReturnOutsideFunction: true, ecmaVersion: "latest", preserveParens: false, loose: true, allowReserved: true });
 
-    this.iterate(ast, (node:any, parent:any = null) => {
-      this.emit(node, node.type, parent, ctx, dynamic, config);
-    });
+  this.iterate(ast, (node: any, parent: any = null) => {
+    this.emit(node, node.type, parent, ctx, dynamic, config);
+  });
 
-    src = this.ctx.modules.estree.generate(ast);
+  src = this.ctx.modules.estree.generate(ast);
 
-    return src;
+  return src;
 }


### PR DESCRIPTION
The preserveParens option on acorn makes it use the (non-standard) `ParenthesizedExpression` node which cant be parsed by ASTring, making token based rewrites ineffective.

This took me hours to figure out.